### PR TITLE
Minor cleanup to avoid PHP deprecation warning

### DIFF
--- a/src/AssertsWithSelectors.php
+++ b/src/AssertsWithSelectors.php
@@ -109,7 +109,7 @@ trait AssertsWithSelectors
 
                 foreach ($selectorContents as $element) {
                     if (Str::contains($element->textContent, $value)) {
-                        PHPUnit::fail("Selector '{$selector}' found with content '${value}'.");
+                        PHPUnit::fail("Selector '{$selector}' found with content '{$value}'.");
                     }
                 }
 


### PR DESCRIPTION
While running tests I saw this output: `PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead`

This is a tiny PR to fix the one place where that is an issue